### PR TITLE
Update build.gradle

### DIFF
--- a/flutter_opencc_ffi_android/android/build.gradle
+++ b/flutter_opencc_ffi_android/android/build.gradle
@@ -26,6 +26,10 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
+    // Conditional for compatibility with AGP <4.2.
+    if (project.android.hasProperty("namespace")) {
+        namespace 'com.whaleread.flutter_opencc_ffi.flutter_opencc_ffi'
+    }
     compileSdkVersion 31
 
     compileOptions {


### PR DESCRIPTION
fix: "Namespace not specified. Please specify a namespace in the module's build.gradle file." when AGP upgrading from 7.4.2 to 8.0.1